### PR TITLE
Added Support for Discord Canary and PTB in Rich Presence

### DIFF
--- a/src/main/java/net/jacobb/resolverpc/ProcessListFunc.java
+++ b/src/main/java/net/jacobb/resolverpc/ProcessListFunc.java
@@ -40,7 +40,7 @@ public class ProcessListFunc {
         String line = sc.nextLine();
         String[] parts = line.split(",");
         String unq = parts[0].substring(1).replaceFirst(".$", "");
-        if (unq.equals("Discord.exe")) {
+        if (unq.equals("Discord.exe") || unq.equals("DiscordCanary.exe") || unq.equals("DiscordPTB.exe")) {
           found.set(true);
         }
       }


### PR DESCRIPTION
Hi there,

I've submitted a pull request to address issue #6 I opened myself where the Rich Presence feature was not functioning correctly with Discord's Canary build.

**Problem:**
The `discordProcessList()` function in ProcessListFunc.java was checking for only the "Discord.exe" process, which corresponds to Discord's stable release, but not the Canary or PTB versions.

**Solution:**
I've **updated** the `discordProcessList()` **function** to **check** for the "DiscordCanary.exe" and "DiscordPTB.exe" processes in addition to "Discord.exe". This update allows the application to **detect and support all versions of Discord**: stable, Canary, and PTB.

I have tested these changes and confirmed that they **fix the original issue**. The Rich Presence feature now **functions as expected** in both the stable and Canary Discord builds.